### PR TITLE
add Developer and Manager to all spaces where OrgManager

### DIFF
--- a/cf-create-user.sh
+++ b/cf-create-user.sh
@@ -63,7 +63,17 @@ then
 	  echo "Org already exists."
 	fi 
   
-  # Make the user a manager. Should this add permissions to org spaces
-  # as well?
+  # Make the user a manager. 
   cf set-org-role $USER_EMAIL $USER_ORG OrgManager
+
+  # Since the typical expectation is that being OrgManager confers
+  # access to the contained spaces as well, but doesn't we'll go
+  # ahead and add those permissions.
+  cf target -o $USER_ORG
+  cf spaces \
+  | awk 'm;/^name/{m=1}' \
+  | while read SPACE_NAME
+      do cf set-space-role $USER_EMAIL $USER_ORG $SPACE_NAME SpaceDeveloper
+         cf set-space-role $USER_EMAIL $USER_ORG $SPACE_NAME SpaceManager
+    done
 fi


### PR DESCRIPTION
Adding a user as an OrgManager doesn't grant SpaceDeveloper or SpaceManager to the spaces within the Org. This is not what most people expect and their first step has been to add themselves or ask to be added.

This adds those perms at the same time as OrgManager.